### PR TITLE
Add assertions to check taskList invariant

### DIFF
--- a/src/main/java/glendon/Glendon.java
+++ b/src/main/java/glendon/Glendon.java
@@ -154,6 +154,7 @@ public class Glendon {
      */
     private String handleDeleteTask(int index) {
         Task deletedTask = this.taskList.deleteTask(index);
+        assert taskList.getCount() == taskList.getTasks().size() : "TaskList count mismatch after modification";
         return "Noted. I've removed this task:\n" + deletedTask
                 + "\nNow you have " + this.taskList.getCount() + " tasks in the list.";
     }
@@ -163,6 +164,7 @@ public class Glendon {
      */
     private String handleAddTask(Task task) {
         this.taskList.addTask(task);
+        assert taskList.getCount() == taskList.getTasks().size() : "TaskList count mismatch after modification";
         return "Got it. I've added this task:\n" + task
                 + "\nNow you have " + this.taskList.getCount() + " tasks in the list.";
     }


### PR DESCRIPTION
Adds assertions when adding or deleting tasks to check that the TaskList getCount method returns a value matching the actual list size.